### PR TITLE
Add travis yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: ruby
+rvm:
+  - 2.3
+  - jruby
+  - rbx-2
+group: stable
+dist: precise
+os: linux


### PR DESCRIPTION
Getting errors caused by travis using ruby < 2.0.0; see if we can force it to use a higher version.
